### PR TITLE
fix(orchestrator): 4 tool-loop bugs — routing, nil panic, missing tools/system-prompt

### DIFF
--- a/edge-agent/src/tools.rs
+++ b/edge-agent/src/tools.rs
@@ -592,9 +592,13 @@ impl EdgeTools {
                 let raw = value_str.trim();
                 // gpiod v2 returns '"17"=inactive' / '"17"=active'
                 // gpiod v1 returns '0' / '1'
-                let state: u8 = if raw.contains("=active") { 1 }
-                    else if raw.contains("=inactive") { 0 }
-                    else { raw.parse::<u8>().unwrap_or(0) };
+                let state: u8 = if raw.contains("=active") {
+                    1
+                } else if raw.contains("=inactive") {
+                    0
+                } else {
+                    raw.parse::<u8>().unwrap_or(0)
+                };
                 ToolResult::ok(serde_json::json!({
                     "pin": pin,
                     "value": state,


### PR DESCRIPTION
## Summary

Four bugs found while testing alex-hub's generic tool calling that prevented local agents from working correctly.

## Bugs Fixed

### 1. Agent routing ignores `msg.To` (orchestrator.go)
`selectAgent()` used FNV hash of sender for load-balancing but never checked `msg.To`. Every `/api/chat` request from the HTTP API (same `from="http-api"`) always resolved to the same agent (whichever the hash landed on), making targeted agent invocation impossible.

**Fix:** Check `msg.To` first; fall back to hash routing only when unset.

### 2. Nil pointer panic on tool-loop path (orchestrator.go)
In `processWithAgent`, the tool-loop branch used `:=` to declare `resp`, shadowing the outer `var resp *Response`. After the tool-loop completed, the outer `resp` was still `nil`, causing a SIGSEGV at `o.outbox <- *resp`.

**Fix:** Use distinct variable names (`tlResp/tlMetrics/tlErr`) and assign the outer `resp` from the tool-loop result.

### 3. Tool schemas not included in LLM request (toolloop.go)
`callLLM` received `tools []ToolSchema` but never set `req.Tools`. The LLM was called with 0 tool definitions, so it could never emit function calls.

**Fix:** Set `req.Tools = tools` in the `ChatRequest`.

### 4. Agent system prompt not passed to LLM (toolloop.go)
`callLLM` hard-coded `SystemPrompt: ""`. The agent's persona, memory protocol, and tool-use instructions were silently dropped from every LLM call.

**Fix:** Add `systemPrompt` parameter to `callLLM` and pass `agent.Def.SystemPrompt` at both call sites.

## Bonus: edge-agent gpiod v2 CLI compatibility (edge-agent/src/tools.rs)
- `gpio_read` was using gpiod v1 positional syntax (`gpioget gpiochip0 17`); gpiod v2 requires `gpioget --chip gpiochip0 17`
- Output format changed from `0`/`1` to `"17"=active`/`"17"=inactive`; parser updated accordingly

## Testing
- Verified alex-hub now routes correctly when `agent: "alex-hub"` is specified
- Verified no panic when tool loop runs with capabilities set
- Verified alex-eye GPIO tool working end-to-end on Pi Zero (ARMv6)