### PR TITLE
feat: connect skillbank to RSI loop — RecordTrajectory hook

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,4 +1,3 @@
-
 linters:
   enable:
     - errcheck

--- a/internal/skillbank/store.go
+++ b/internal/skillbank/store.go
@@ -8,6 +8,7 @@ import (
 	"os"
 	"path/filepath"
 	"sync"
+	"time"
 )
 
 // ErrNotFound is returned when a skill or mistake is not found by ID.
@@ -269,4 +270,28 @@ func (fs *FileStore) DeleteMistake(id string) error {
 	}
 	delete(fs.mistakes, id)
 	return fs.flushMistakes()
+}
+
+// SkillFromTrajectory creates a raw skill entry from a trajectory for later distillation.
+// The returned skill has Source="trajectory" and Confidence=0.5 (0.7 on success).
+// It is intended to be stored immediately and distilled into a refined skill later.
+func SkillFromTrajectory(t Trajectory) Skill {
+	source := "trajectory"
+	confidence := 0.5
+	if t.Success {
+		confidence = 0.7
+	}
+	now := time.Now()
+	return Skill{
+		ID:          fmt.Sprintf("traj-%d", now.UnixNano()),
+		Title:       fmt.Sprintf("Trajectory: %s", t.TaskDescription),
+		Principle:   "Raw trajectory — pending distillation",
+		WhenToApply: t.TaskType,
+		Category:    "trajectory",
+		TaskType:    t.TaskType,
+		Source:      source,
+		Confidence:  confidence,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
 }


### PR DESCRIPTION
Wires the new skillbank package (PR #22) into the RSI observer cycle. Every task outcome now records a trajectory for future LLM distillation into reusable skills.

## What changed

### `internal/skillbank/store.go`
- Added `SkillFromTrajectory(t Trajectory) Skill` helper — converts a raw trajectory into a `Skill` entry with `Category="trajectory"`, `Source="trajectory"`, and `Confidence=0.5` (0.7 on success).

### `internal/rsi/observer.go`
- Added `skillStore skillbank.Store` field to `Observer`
- Added `WithSkillStore(store skillbank.Store) *Observer` fluent setter
- Added `RecordTrajectory(t skillbank.Trajectory)` method — logs to skillbank, best-effort (errors logged, never fatal)
- `Record()` now calls `RecordTrajectory` after persisting each outcome

### `internal/rsi/loop.go`
- `NewLoop` initialises a `skillbank.FileStore` at `cfg.DataDir/skillbank.jsonl` and attaches it to the observer via `WithSkillStore`

### `internal/rsi/loop_test.go`
- Added `TestRSILoop_RecordsTrajectoryOnOutcome` — records an outcome, verifies skillbank JSONL was written with correct category/source/task_type/confidence

## Tests
```
ok  github.com/clawinfra/evoclaw/internal/rsi       0.006s
ok  github.com/clawinfra/evoclaw/internal/skillbank 0.024s
```
golangci-lint: no warnings or errors.