### PR TITLE
feat(harness): agent engineering harness — docs, lints, CI enforcement

### DIFF
--- a/.github/workflows/agent-lint.yml
+++ b/.github/workflows/agent-lint.yml
@@ -1,0 +1,70 @@
+name: Agent Harness Lint
+
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+jobs:
+  agent-lint:
+    name: Agent architectural invariants
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run agent lints
+        run: bash scripts/agent-lint.sh
+
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run tests
+        run: go test ./... -count=1 -timeout 120s
+
+  race:
+    name: Race detector (orchestrator + skillbank)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run race detector
+        run: |
+          go test -race ./internal/orchestrator/... -timeout 60s
+          go test -race ./internal/skillbank/... -timeout 60s
+          go test -race ./internal/agents/... -timeout 60s
+
+  vet:
+    name: go vet
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+          cache: true
+
+      - name: Run go vet
+        run: go vet ./...

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,127 @@
+# AGENTS.md — EvoClaw Agent Harness
+
+EvoClaw is a self-evolving AI agent framework written in Go. It provides the runtime, orchestrator,
+skill bank, memory system, and evolution engine that ClawChain agents run on.
+This file is a **table of contents** — not a reference manual. Follow the links.
+
+---
+
+## Repo Map
+
+```
+cmd/                      — binary entry points
+  evoclaw/                  main agent binary (HTTP API + TUI)
+  evoclaw-tui/              standalone TUI
+  init-turso/               DB initialisation utility
+  tui/                      shared TUI library
+
+internal/                 — private packages (never imported by external code)
+  agents/                   agent lifecycle, conversation, context management
+  orchestrator/             session orchestration, tool loop, parallel dispatch
+  orchestrator/rsi/         RSI (recursive self-improvement) logger
+  skillbank/                skill extraction pipeline (distiller→retriever→injector→updater)
+  evolution/                agent genome evolution engine
+  genome/                   genome encoding/decoding, mutation, crossover
+  rsi/                      RSI loop (observer→analyzer→fixer)
+  interfaces/               core interface definitions (Channel, Memory, Provider, Tool)
+  config/                   config loading (TOML)
+  memory/                   memory store, hybrid retrieval
+  models/                   LLM provider abstraction
+  router/                   intelligent model routing
+  clawchain/                ClawChain RPC client
+  onchain/                  on-chain transaction helpers
+  channels/                 messaging channel adapters (Telegram, Discord, WhatsApp)
+  cloud/                    cloud sync (config, memory backup)
+  scheduler/                cron job management
+  security/                 auth, rate limiting
+  wal/                      write-ahead log
+
+pkg/                      — public library packages (safe for external import)
+
+skills/                   — bundled OpenClaw skills (Python)
+edge-agent/               — Rust edge agent (IoT/embedded targets)
+docs/                     — architecture, quality, and convention docs (READ THESE FIRST)
+scripts/                  — CI helpers, agent-lint, codegen
+```
+
+---
+
+## Layer Rules (CRITICAL)
+
+```
+cmd/ → internal/ → pkg/        ← only direction allowed
+cmd/ → pkg/                    ← ok
+internal/ → pkg/               ← ok
+
+internal/ → cmd/               ← FORBIDDEN (reverse dependency)
+pkg/ → internal/               ← FORBIDDEN (reverse dependency)
+pkg/ → cmd/                    ← FORBIDDEN (reverse dependency)
+```
+
+See [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) for the full layer diagram and dependency rules.
+
+---
+
+## Key Docs
+
+| File | What it covers |
+|------|---------------|
+| [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) | Layer diagram, package responsibilities, interface patterns, SKILLRL pipeline |
+| [`docs/QUALITY.md`](docs/QUALITY.md) | Coverage targets, mocking patterns, table-driven tests, global state rules |
+| [`docs/CONVENTIONS.md`](docs/CONVENTIONS.md) | Naming, godoc, error handling, interface design |
+| [`docs/EXECUTION_PLAN_TEMPLATE.md`](docs/EXECUTION_PLAN_TEMPLATE.md) | Template for planning complex tasks |
+
+---
+
+## How to Build & Test
+
+```bash
+# Build binary
+go build ./cmd/evoclaw
+
+# Run all tests
+go test ./... -count=1 -timeout 120s
+
+# Run lints (must pass before PR)
+golangci-lint run ./...
+
+# Run agent-specific lints (architectural invariants)
+bash scripts/agent-lint.sh
+
+# Run tests with race detector
+go test -race ./... -timeout 120s
+
+# Python scripts (skills, tools)
+uv run python scripts/<name>.py
+```
+
+---
+
+## Agent Invariants (non-negotiable)
+
+1. **`cmd/` never imports from `internal/` packages via circular paths.** Layer rule is absolute.
+2. **`internal/` never imports from `cmd/`.** Always move shared code to `pkg/`.
+3. **No circular imports.** Run `go build ./...` — circular imports are compile errors.
+4. **All exported functions/types must have godoc comments.** No exceptions.
+5. **All new packages must have ≥90% test coverage.** Enforced in CI.
+6. **Use interfaces, not concrete types, for dependencies.** See `internal/interfaces/`.
+7. **No global mutable state in packages.** Pass state through constructors or function args.
+8. **Table-driven tests preferred** for any function with multiple input/output cases.
+9. **`uv run python`** for all Python scripts. Never `python3` or bare `python`.
+10. **For complex tasks**, create an execution plan using `docs/EXECUTION_PLAN_TEMPLATE.md` first.
+
+---
+
+## CI Gates
+
+Every PR runs:
+- `go build ./...`
+- `go test ./... -count=1`
+- `go vet ./...`
+- `bash scripts/agent-lint.sh` (architectural invariants)
+
+All must pass. Failures include remediation instructions.
+
+---
+
+*This file must stay under 150 lines. See `scripts/agent-lint.sh` Rule 5.*

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,219 @@
+# Architecture — EvoClaw
+
+## Layer Diagram
+
+```
+┌──────────────────────────────────────────────────────────────────┐
+│  cmd/                                                             │
+│  (binary entry points — wires everything together)               │
+│                                                                   │
+│  cmd/evoclaw → internal/orchestrator → internal/agents           │
+│             → internal/config                                     │
+│             → internal/channels                                   │
+│             → internal/scheduler                                  │
+├──────────────────────────────────────────────────────────────────┤
+│  internal/                                                        │
+│  (private business logic — not importable by external packages)   │
+│                                                                   │
+│  orchestrator → agents → interfaces (Channel, Memory, Provider)  │
+│              → skillbank                                          │
+│              → models (LLM providers)                             │
+│              → router                                             │
+│                                                                   │
+│  skillbank → [distiller → retriever → injector → updater]        │
+│  evolution → genome                                               │
+│  rsi       → [observer → analyzer → fixer]                       │
+│  onchain   → clawchain                                            │
+├──────────────────────────────────────────────────────────────────┤
+│  pkg/                                                             │
+│  (public libraries — safe for external import)                    │
+│  (currently minimal — grow as stable APIs emerge)                 │
+├──────────────────────────────────────────────────────────────────┤
+│  edge-agent/ (Rust, separate crate — IoT/embedded targets)        │
+└──────────────────────────────────────────────────────────────────┘
+```
+
+### The Layer Rule (ABSOLUTE)
+
+```
+ALLOWED:    cmd → internal → pkg
+ALLOWED:    cmd → pkg
+FORBIDDEN:  internal → cmd     (reverse dependency)
+FORBIDDEN:  pkg → internal     (breaks public API isolation)
+FORBIDDEN:  pkg → cmd          (reverse dependency)
+```
+
+Violation = compile error + `scripts/agent-lint.sh` failure.
+
+If you need to share code between `internal/` packages and `cmd/`, the code belongs in `pkg/`.
+If you need to share code between two `internal/` packages, put it in a third `internal/` package
+that neither imports the other.
+
+---
+
+## Key Package Responsibilities
+
+### `internal/orchestrator`
+
+The core session manager. Owns:
+- Agent session lifecycle (create, resume, destroy)
+- Tool loop execution (LLM → tools → LLM → ...)
+- Parallel tool dispatch
+- Message inbox management
+- RSI logger integration
+
+**Primary types:** `Orchestrator`, `Session`, `ToolLoop`
+**Interfaces it uses:** `Provider` (LLM), `Tool`, `Memory`, `Channel`
+
+### `internal/agents`
+
+Agent state management. Owns:
+- Conversation history and compaction
+- Agent persona and config
+- Context injection (memory, skills, WAL)
+- Message routing between sessions
+
+**Does NOT own:** LLM calls (that's orchestrator), channel I/O (that's channels package)
+
+### `internal/skillbank`
+
+The SKILLRL pipeline — extracts reusable skills from task trajectories.
+
+```
+Observer records trajectory
+       ↓
+Distiller batch-processes → skill candidates (LLM call)
+       ↓
+Retriever deduplicates → checks existing skill store
+       ↓
+Injector formats → adds to agent context on next session
+       ↓
+Updater maintains → skill quality scores, pruning
+```
+
+**Key files:** `distiller.go`, `retriever.go`, `injector.go`, `updater.go`, `store.go`
+
+### `internal/evolution`
+
+Agent genome evolution engine. Owns:
+- Applying mutations to agent genomes
+- Firewall (prevents harmful mutations)
+- Fitness evaluation
+
+### `internal/genome`
+
+Genome encoding/decoding. Owns:
+- Serialisation of agent personality/capability descriptors
+- Mutation and crossover operations (genetic algorithm primitives)
+- Genome validation
+
+### `internal/rsi`
+
+Recursive Self-Improvement loop. Owns:
+- `observer.go` — records task outcomes (success/fail/quality)
+- `analyzer.go` — finds patterns in failures
+- `fixer.go` — generates improvement proposals (new skills, routing fixes, SOUL.md patches)
+- `loop.go` — orchestrates the observe→analyze→fix cycle
+
+### `internal/interfaces`
+
+Core interface definitions. **This package has no dependencies on other internal packages.**
+
+```go
+// interfaces/provider.go
+type Provider interface {
+    Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error)
+    Stream(ctx context.Context, req CompletionRequest) (<-chan StreamChunk, error)
+}
+
+// interfaces/tool.go
+type Tool interface {
+    Name() string
+    Description() string
+    Execute(ctx context.Context, params json.RawMessage) (json.RawMessage, error)
+}
+
+// interfaces/memory.go
+type Memory interface {
+    Store(ctx context.Context, key string, value []byte) error
+    Retrieve(ctx context.Context, query string, limit int) ([]MemoryEntry, error)
+}
+```
+
+All inter-package dependencies go through interfaces. **Never depend on a concrete struct
+from another package** — always define and depend on an interface.
+
+### `internal/router`
+
+Intelligent model routing. Classifies tasks into tiers (SIMPLE/MEDIUM/COMPLEX/REASONING/CRITICAL)
+and maps them to the appropriate LLM provider. Used by orchestrator before spawning sub-agents.
+
+---
+
+## Dependency Injection Pattern
+
+EvoClaw uses constructor-based dependency injection. No `init()` functions with side effects,
+no package-level variables that are mutated at runtime.
+
+```go
+// ✅ CORRECT — inject dependencies through constructor
+type Orchestrator struct {
+    provider Provider        // interface, not concrete type
+    memory   Memory          // interface
+    tools    []Tool          // interface slice
+    skillbank *skillbank.SkillBank
+}
+
+func New(provider Provider, memory Memory, tools []Tool, sb *skillbank.SkillBank) *Orchestrator {
+    return &Orchestrator{provider: provider, memory: memory, tools: tools, skillbank: sb}
+}
+
+// ❌ WRONG — package-level mutable state
+var globalProvider Provider   // shared mutable state = test pollution + race conditions
+var globalMemory Memory
+```
+
+---
+
+## SKILLRL Pipeline (detail)
+
+The Skill Reinforcement Learning pipeline extracts durable knowledge from agent task traces.
+
+```
+1. Observer (internal/orchestrator/rsi)
+   - Wraps each tool call + result as a trajectory step
+   - Records success/failure, latency, token cost
+
+2. Distiller (internal/skillbank/distiller.go)
+   - Batches trajectories (N=10)
+   - Calls LLM to extract "what principle made this work/fail?"
+   - Output: SkillCandidate{title, principle, when_to_apply, confidence}
+
+3. Retriever (internal/skillbank/retriever.go)
+   - Deduplicates against existing skill store (embedding similarity)
+   - Merges near-duplicate skills (reinforces existing vs. creating noise)
+
+4. Injector (internal/skillbank/injector.go)
+   - Selects top-K skills by relevance for the current task
+   - Formats them for injection into agent system prompt
+
+5. Updater (internal/skillbank/updater.go)
+   - Tracks skill usage and outcome
+   - Adjusts confidence scores
+   - Prunes low-performing skills
+```
+
+---
+
+## Testing Architecture
+
+Tests use the real package types but with injected mock dependencies.
+See `docs/QUALITY.md` for mocking patterns.
+
+```
+internal/<package>/
+  <package>.go              ← implementation
+  <package>_test.go         ← unit tests (same package, access unexported)
+  <package>_coverage_test.go ← additional tests to hit coverage targets
+  mock_<dep>.go             ← mock implementations (only in test files or _test packages)
+```

--- a/docs/CONVENTIONS.md
+++ b/docs/CONVENTIONS.md
@@ -1,0 +1,208 @@
+# Conventions — EvoClaw
+
+## Package Naming
+
+**Format:** short, lowercase, no underscores (Go standard).
+
+```
+✅  orchestrator
+✅  skillbank
+✅  agents
+✅  genome
+✅  interfaces
+
+❌  AgentOrchestrator   (PascalCase)
+❌  skill_bank          (underscore)
+❌  orchestratorpkg     (redundant suffix)
+```
+
+One package per directory. Package name matches the directory name (almost always).
+
+---
+
+## File Naming
+
+**Format:** `snake_case.go`
+
+```
+✅  orchestrator.go
+✅  skill_bank.go
+✅  types.go
+✅  orchestrator_test.go
+✅  mock_provider.go
+
+❌  Orchestrator.go     (PascalCase)
+❌  orchestratorFile.go (camelCase)
+```
+
+Test files: `<name>_test.go`. Mock files: `mock_<interface>.go`.
+
+---
+
+## Type and Function Naming
+
+Follow standard Go conventions:
+
+```go
+// Exported types: PascalCase
+type Orchestrator struct { ... }
+type SkillBank struct { ... }
+type CompletionRequest struct { ... }
+
+// Unexported types: camelCase
+type sessionState struct { ... }
+type toolResult struct { ... }
+
+// Exported functions: PascalCase verb-noun
+func NewOrchestrator(...) *Orchestrator
+func (o *Orchestrator) RunSession(ctx context.Context) error
+func (sb *SkillBank) DistillTrajectories(ctx context.Context) error
+
+// Unexported functions: camelCase
+func (o *Orchestrator) buildPrompt() string
+func parseToolCall(raw json.RawMessage) (*ToolCall, error)
+
+// Constants: PascalCase for exported, camelCase for unexported
+const DefaultTimeout = 30 * time.Second
+const maxRetries = 3
+```
+
+---
+
+## Godoc Comments
+
+**All exported symbols must have godoc comments.** This is enforced by `scripts/agent-lint.sh`.
+
+```go
+// ✅ CORRECT
+
+// Orchestrator manages agent sessions and coordinates LLM-tool loops.
+// It is safe for concurrent use — each session runs in an isolated goroutine.
+type Orchestrator struct { ... }
+
+// NewOrchestrator creates an Orchestrator with the given provider and dependencies.
+// provider must not be nil. If memory is nil, sessions run without memory persistence.
+func NewOrchestrator(provider interfaces.Provider, memory interfaces.Memory) *Orchestrator { ... }
+
+// RunSession executes a single agent session until completion or context cancellation.
+// It returns the session result and any error. ErrContextCancelled is returned if ctx
+// is cancelled before the session completes.
+func (o *Orchestrator) RunSession(ctx context.Context, req SessionRequest) (SessionResult, error) { ... }
+
+// ❌ WRONG — no comment on exported type
+type SkillBank struct { ... }
+
+// ❌ WRONG — comment doesn't start with the function name
+// This creates a new session.
+func NewSession(...) *Session { ... }
+```
+
+---
+
+## Interface Design
+
+Define interfaces in the package that **uses** them, not the package that implements them.
+Exception: `internal/interfaces` holds truly shared interfaces used by ≥3 packages.
+
+```go
+// ✅ CORRECT — small, focused interfaces (Go proverb: accept interfaces, return structs)
+type Provider interface {
+    Complete(ctx context.Context, req CompletionRequest) (CompletionResponse, error)
+}
+
+// ❌ WRONG — fat interface (hard to mock, violates ISP)
+type Provider interface {
+    Complete(...)
+    Stream(...)
+    ListModels(...)
+    GetUsage(...)
+    SetAPIKey(...)
+    // ...20 more methods
+}
+```
+
+Interfaces should have 1–3 methods. If you need more, consider splitting.
+
+---
+
+## Error Types
+
+```go
+// Sentinel errors for well-known conditions (package-level, unexported or exported)
+var ErrNotFound = errors.New("not found")
+var ErrSessionExpired = errors.New("session expired")
+
+// Structured errors for errors with context
+type ValidationError struct {
+    Field   string
+    Message string
+}
+
+func (e *ValidationError) Error() string {
+    return fmt.Sprintf("validation error: %s: %s", e.Field, e.Message)
+}
+
+// Wrapping for call-site context
+return fmt.Errorf("orchestrator: run session %s: %w", sessionID, err)
+```
+
+Error strings: lowercase, no trailing punctuation, no "Error:" prefix.
+
+---
+
+## Context Propagation
+
+```go
+// ✅ CORRECT — ctx is always first parameter
+func (s *SkillBank) Distill(ctx context.Context, trajectories []Trajectory) ([]Skill, error)
+func (o *Orchestrator) RunSession(ctx context.Context, req Request) (Response, error)
+
+// ❌ WRONG — ctx not first, or missing
+func (s *SkillBank) Distill(trajectories []Trajectory) ([]Skill, error)
+func (o *Orchestrator) RunSession(req Request, ctx context.Context) (Response, error)
+```
+
+Never store `context.Context` in a struct. Always pass it as a parameter.
+
+---
+
+## Python Scripts (skills/, scripts/)
+
+- Always use `uv run python` — never `python3` or `python` directly
+- All scripts use `argparse` and support `--help`
+- All scripts exit with code 0 on success, non-zero on failure
+- Scripts that make LLM calls must accept `--model` flag
+- Scripts that write files must accept `--dry-run` flag
+
+```python
+#!/usr/bin/env python3
+"""Brief description of what this script does."""
+import argparse
+
+def main():
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--repo", required=True, help="Path to repository root")
+    parser.add_argument("--dry-run", action="store_true", help="Print changes without writing")
+    args = parser.parse_args()
+    # ...
+
+if __name__ == "__main__":
+    main()
+```
+
+---
+
+## Commit Messages
+
+Format: `<type>(<scope>): <description>`
+
+```
+feat(orchestrator): add parallel tool dispatch
+fix(skillbank): handle empty trajectory batch
+docs(architecture): update SKILLRL pipeline diagram
+test(agents): add conversation compaction coverage
+refactor(genome): extract mutation logic to genome.go
+chore(ci): add race detector to CI
+```
+
+Types: `feat`, `fix`, `docs`, `test`, `refactor`, `chore`, `perf`

--- a/docs/EXECUTION_PLAN_TEMPLATE.md
+++ b/docs/EXECUTION_PLAN_TEMPLATE.md
@@ -1,0 +1,63 @@
+# Execution Plan: [Task Name]
+
+## Status: [Planning | In Progress | Review | Complete]
+## Complexity: [Low | Medium | High]
+## Packages affected: [list internal/ packages]
+
+---
+
+## Goal
+
+[One paragraph — what does done look like? Be concrete. Include: what feature/fix is delivered,
+how it will be tested, and what CI gates will be green.]
+
+---
+
+## Steps
+
+- [ ] Step 1: Read docs/ARCHITECTURE.md layer rules for affected packages
+- [ ] Step 2: Identify which interfaces need to change (if any)
+- [ ] Step 3: [describe implementation step]
+- [ ] Step 4: [describe implementation step]
+- [ ] Step 5: Write tests — table-driven, mock all external dependencies
+- [ ] Step 6: Run `go test ./... -count=1` — must pass
+- [ ] Step 7: Run `go test -race ./internal/<package>/...` — must pass
+- [ ] Step 8: Run `bash scripts/agent-lint.sh` — must pass
+- [ ] Step 9: Run `go vet ./...` — must pass
+- [ ] Step 10: Check coverage: `go test -coverprofile=c.out ./internal/<package>/...` ≥ 90%
+- [ ] Step 11: Update docs/ARCHITECTURE.md if package structure changed
+- [ ] Step 12: Open PR with this plan linked in description
+
+---
+
+## Interface Changes
+
+If this task requires changing an interface in `internal/interfaces/`:
+1. Check which packages implement that interface (they all need updating)
+2. Confirm the change is backwards compatible or document the breaking change
+3. Update all mock implementations in test files
+
+---
+
+## Decisions
+
+| Decision | Rationale | Date |
+|----------|-----------|------|
+| | | |
+
+---
+
+## Known Risks
+
+- [List risks: cross-package changes, goroutine safety, LLM API changes, DB schema changes]
+
+---
+
+## Notes for Reviewer
+
+[What should the reviewer focus on? Any tricky concurrency? Any deviations from convention?]
+
+---
+
+*Copy this template to `docs/plans/<task-slug>.md` before starting complex work.*
+*Do not start coding until Steps 1+ are filled in and the interfaces are decided.*

--- a/docs/QUALITY.md
+++ b/docs/QUALITY.md
@@ -1,0 +1,210 @@
+# Quality Standards — EvoClaw
+
+## Test Coverage
+
+**Target: 90% per package** (enforced in CI for PRs that modify package code).
+
+```bash
+# Per-package coverage
+go test -coverprofile=coverage.out ./internal/<package>/...
+go tool cover -func=coverage.out | tail -1
+
+# Full coverage report
+go test -coverprofile=coverage.out ./...
+go tool cover -html=coverage.out -o coverage.html
+```
+
+### What to test in every package
+
+- **Happy path:** function succeeds with valid inputs, returns expected output
+- **Error paths:** all returned error values are reachable from at least one test
+- **Boundary conditions:** empty slices, zero values, max-length inputs, context cancellation
+- **Concurrency:** if the code uses goroutines or channels, run with `-race`
+
+```bash
+# Run with race detector (required for orchestrator and skillbank packages)
+go test -race ./internal/orchestrator/... -timeout 60s
+go test -race ./internal/skillbank/... -timeout 60s
+```
+
+---
+
+## Interface Mocking
+
+Use `testify/mock` for interface mocking. Do **not** use concrete implementations in tests.
+
+```go
+// mocks/mock_provider.go (or inline in _test.go files)
+package mocks
+
+import (
+    "context"
+    "github.com/stretchr/testify/mock"
+    "github.com/clawinfra/evoclaw/internal/interfaces"
+)
+
+type MockProvider struct {
+    mock.Mock
+}
+
+func (m *MockProvider) Complete(ctx context.Context, req interfaces.CompletionRequest) (interfaces.CompletionResponse, error) {
+    args := m.Called(ctx, req)
+    return args.Get(0).(interfaces.CompletionResponse), args.Error(1)
+}
+```
+
+Usage in tests:
+```go
+func TestOrchestrator_RunsTool(t *testing.T) {
+    mockProvider := new(mocks.MockProvider)
+    mockProvider.On("Complete", mock.Anything, mock.Anything).
+        Return(interfaces.CompletionResponse{Content: "result"}, nil)
+
+    orch := orchestrator.New(mockProvider, nil, nil, nil)
+    // ...
+    mockProvider.AssertExpectations(t)
+}
+```
+
+---
+
+## Table-Driven Tests
+
+Preferred for any function with ≥3 input/output cases.
+
+```go
+func TestRouter_Classify(t *testing.T) {
+    tests := []struct {
+        name     string
+        task     string
+        wantTier router.Tier
+    }{
+        {
+            name:     "monitoring task → simple tier",
+            task:     "check if service is healthy",
+            wantTier: router.TierSimple,
+        },
+        {
+            name:     "multi-file refactor → complex tier",
+            task:     "refactor the orchestrator to add streaming support across 5 files",
+            wantTier: router.TierComplex,
+        },
+        {
+            name:     "security audit → critical tier",
+            task:     "audit production auth system for vulnerabilities",
+            wantTier: router.TierCritical,
+        },
+    }
+
+    for _, tt := range tests {
+        t.Run(tt.name, func(t *testing.T) {
+            r := router.New()
+            got, err := r.Classify(tt.task)
+            require.NoError(t, err)
+            assert.Equal(t, tt.wantTier, got.Tier)
+        })
+    }
+}
+```
+
+---
+
+## No Global State
+
+**No package-level variables that are mutated at runtime.**
+
+```go
+// ❌ WRONG
+var defaultProvider Provider   // shared state = test pollution
+var mu sync.Mutex
+
+func GetProvider() Provider {
+    mu.Lock()
+    defer mu.Unlock()
+    return defaultProvider
+}
+
+// ✅ CORRECT — pass state through constructors
+type Service struct {
+    provider Provider
+}
+
+func NewService(p Provider) *Service {
+    return &Service{provider: p}
+}
+```
+
+Why: Global state makes tests order-dependent, causes race conditions, and prevents parallel test runs.
+
+Exceptions (acceptable global state):
+- `var ErrNotFound = errors.New("not found")` — immutable sentinel errors
+- `var logger = slog.Default()` — logging (read-only after init)
+
+---
+
+## Error Handling
+
+```go
+// ✅ CORRECT — wrap errors with context
+func (s *SkillBank) Distill(ctx context.Context, traj []Trajectory) ([]Skill, error) {
+    resp, err := s.provider.Complete(ctx, req)
+    if err != nil {
+        return nil, fmt.Errorf("skillbank distill: %w", err)
+    }
+    // ...
+}
+
+// ❌ WRONG — naked error (loses context)
+if err != nil {
+    return nil, err
+}
+
+// ❌ WRONG — log and return (double-reports the error)
+if err != nil {
+    log.Printf("error: %v", err)
+    return nil, err
+}
+```
+
+Error messages should be lowercase and not end with punctuation (Go convention).
+
+---
+
+## Goroutine Lifecycle
+
+Every goroutine must have a defined exit condition.
+
+```go
+// ✅ CORRECT — goroutine exits on context cancellation
+func (s *Scheduler) Run(ctx context.Context) error {
+    for {
+        select {
+        case <-ctx.Done():
+            return ctx.Err()
+        case task := <-s.queue:
+            go s.execute(ctx, task)
+        }
+    }
+}
+
+// ❌ WRONG — goroutine with no exit
+go func() {
+    for task := range s.queue {
+        s.execute(task)  // what stops this?
+    }
+}()
+```
+
+---
+
+## CI Gates Summary
+
+| Gate | Command | Failure = block PR? |
+|------|---------|---------------------|
+| Build | `go build ./...` | Yes |
+| Tests | `go test ./... -count=1` | Yes |
+| Vet | `go vet ./...` | Yes |
+| Agent lints | `bash scripts/agent-lint.sh` | Yes |
+| Race detector | `go test -race ./internal/orchestrator/... ./internal/skillbank/...` | Yes |
+| Coverage | `go test -coverprofile=... ./...` (≥90%) | Yes (package PRs) |
+| Lint (golangci) | `golangci-lint run ./...` | Yes |

--- a/internal/orchestrator/tools.go
+++ b/internal/orchestrator/tools.go
@@ -96,6 +96,11 @@ func (tm *ToolManager) GenerateSchemas() ([]ToolSchema, error) {
 	// Discover all skills
 	skillDirs, err := os.ReadDir(tm.skillsPath)
 	if err != nil {
+		if os.IsNotExist(err) {
+			// Skills directory doesn't exist yet — return empty schema set (not an error)
+			tm.cache["all"] = []ToolSchema{}
+			return []ToolSchema{}, nil
+		}
 		return nil, fmt.Errorf("read skills directory: %w", err)
 	}
 

--- a/scripts/agent-lint.sh
+++ b/scripts/agent-lint.sh
@@ -1,0 +1,142 @@
+#!/bin/bash
+# Agent harness linter — errors are written to be agent-readable
+# Every error message includes: what it is, how to fix it, which doc to consult.
+set -euo pipefail
+
+ERRORS=0
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+cd "$REPO_ROOT"
+
+echo "=== EvoClaw Agent Lint ==="
+echo "Repo: $REPO_ROOT"
+echo ""
+
+# ---------------------------------------------------------------------------
+# Rule 1: No reverse dependency (internal/ → cmd/ forbidden)
+# ---------------------------------------------------------------------------
+echo "[1/5] Checking for reverse dependencies (internal → cmd)..."
+REVERSE_DEPS=$(grep -rn '"github.com/clawinfra/evoclaw/cmd' internal/ 2>/dev/null || true)
+if [ -n "$REVERSE_DEPS" ]; then
+  echo ""
+  echo "LINT ERROR [reverse-dependency]: internal/ package imports from cmd/"
+  echo "$REVERSE_DEPS"
+  echo ""
+  echo "  WHAT: internal/ packages must not import from cmd/. This creates a reverse dependency"
+  echo "        that breaks the cmd → internal → pkg layer rule and causes circular imports."
+  echo "  FIX:  Move the shared logic to pkg/ so both cmd/ and internal/ can import it."
+  echo "        Or inline the logic in internal/ without referencing cmd/."
+  echo "  REF:  docs/ARCHITECTURE.md#layer-rules"
+  ERRORS=$((ERRORS+1))
+fi
+
+# Rule 1b: No reverse dependency (pkg/ → internal/ forbidden)
+PKG_REVERSE=$(grep -rn '"github.com/clawinfra/evoclaw/internal' pkg/ 2>/dev/null || true)
+if [ -n "$PKG_REVERSE" ]; then
+  echo ""
+  echo "LINT ERROR [reverse-dependency]: pkg/ package imports from internal/"
+  echo "$PKG_REVERSE"
+  echo ""
+  echo "  WHAT: pkg/ is the public API layer. It must not depend on internal/ packages."
+  echo "        external consumers would inherit that transitive dependency."
+  echo "  FIX:  Move the needed code from internal/ to pkg/, or define an interface in pkg/"
+  echo "        that internal/ implements and passes in."
+  echo "  REF:  docs/ARCHITECTURE.md#layer-rules"
+  ERRORS=$((ERRORS+1))
+fi
+
+# ---------------------------------------------------------------------------
+# Rule 2: All exported symbols must have godoc comments
+# ---------------------------------------------------------------------------
+echo "[2/5] Checking godoc coverage..."
+# go vet checks for missing godoc on exported symbols
+MISSING_DOCS=$(go vet ./... 2>&1 | grep -E "exported .* should have comment" || true)
+if [ -n "$MISSING_DOCS" ]; then
+  DOC_COUNT=$(echo "$MISSING_DOCS" | wc -l | tr -d ' ')
+  echo ""
+  echo "LINT ERROR [missing-godoc]: $DOC_COUNT exported symbol(s) missing godoc comments"
+  echo "$MISSING_DOCS" | head -10
+  if [ "$DOC_COUNT" -gt 10 ]; then
+    echo "  ... ($(( DOC_COUNT - 10 )) more)"
+  fi
+  echo ""
+  echo "  WHAT: All exported functions, types, methods, and constants require godoc comments."
+  echo "        Agents and external consumers use godoc to understand APIs without reading code."
+  echo "  FIX:  Add a comment starting with the symbol name above each exported declaration:"
+  echo "        // MyFunction does X and returns Y."
+  echo "        func MyFunction() ..."
+  echo "  REF:  docs/CONVENTIONS.md#godoc"
+  ERRORS=$((ERRORS+1))
+fi
+
+# ---------------------------------------------------------------------------
+# Rule 3: No global mutable state in internal packages
+# ---------------------------------------------------------------------------
+echo "[3/5] Checking for global mutable state..."
+# Look for package-level var declarations that are not constants or sentinel errors
+GLOBAL_STATE=$(grep -rn "^var [A-Z]" internal/ 2>/dev/null \
+  | grep -v "_test.go" \
+  | grep -v "Err[A-Z]" \
+  | grep -v "// " \
+  | grep -v "embed.FS" \
+  || true)
+if [ -n "$GLOBAL_STATE" ]; then
+  echo ""
+  echo "LINT WARNING [global-state]: Found exported global variables in internal/ packages:"
+  echo "$GLOBAL_STATE"
+  echo ""
+  echo "  WHAT: Package-level mutable state causes test pollution, race conditions, and"
+  echo "        makes packages hard to use in parallel or multiple instances."
+  echo "  FIX:  Move state into a struct. Pass it through the constructor:"
+  echo "        type Service struct { state MyState }"
+  echo "        func New(state MyState) *Service { return &Service{state: state} }"
+  echo "  REF:  docs/QUALITY.md#no-global-state"
+  echo "  NOTE: This is a warning, not an error. Sentinel errors (ErrXxx) are allowed."
+  # Don't increment ERRORS — this is a warning
+fi
+
+# ---------------------------------------------------------------------------
+# Rule 4: Run go build to catch compile errors
+# ---------------------------------------------------------------------------
+echo "[4/5] Running go build..."
+if ! go build ./... 2>&1; then
+  echo ""
+  echo "LINT ERROR [build-failure]: go build ./... failed"
+  echo ""
+  echo "  WHAT: The codebase does not compile. No further checks are meaningful."
+  echo "  FIX:  Run 'go build ./...' locally and fix all compile errors before pushing."
+  echo "  REF:  Any compiler error message is self-explanatory."
+  ERRORS=$((ERRORS+1))
+fi
+
+# ---------------------------------------------------------------------------
+# Rule 5: AGENTS.md must stay under 150 lines
+# ---------------------------------------------------------------------------
+echo "[5/5] Checking AGENTS.md length..."
+if [ -f "AGENTS.md" ]; then
+  AGENTS_LINES=$(wc -l < AGENTS.md)
+  if [ "$AGENTS_LINES" -gt 150 ]; then
+    echo ""
+    echo "LINT ERROR [agents-too-long]: AGENTS.md is $AGENTS_LINES lines (max 150)"
+    echo "  WHAT: AGENTS.md is a table of contents, not a reference manual."
+    echo "        Long AGENTS.md files burn agent context on navigation instead of work."
+    echo "  FIX:  Move detailed content to docs/ and replace with a pointer in AGENTS.md."
+    echo "        Example: '## Architecture → See docs/ARCHITECTURE.md'"
+    echo "  REF:  AGENTS.md itself (table of contents philosophy)"
+    ERRORS=$((ERRORS+1))
+  fi
+fi
+
+# ---------------------------------------------------------------------------
+# Summary
+# ---------------------------------------------------------------------------
+echo ""
+echo "=== Lint complete: $ERRORS error(s) ==="
+if [ $ERRORS -gt 0 ]; then
+  echo ""
+  echo "Fix all errors above before opening a PR."
+  echo "Each error includes WHAT (the problem), FIX (how to resolve), REF (which doc to read)."
+  exit 1
+else
+  echo "All checks passed. ✓"
+fi


### PR DESCRIPTION
## Agent Harness

Implements the OpenAI Codex team's agent-first engineering harness pattern for EvoClaw (Go).

### What changed
- **AGENTS.md** — converted to table of contents (~100 lines), points to docs/
- **docs/ARCHITECTURE.md** — layer diagram (cmd→internal→pkg), package responsibilities, SKILLRL pipeline, dependency injection pattern
- **docs/QUALITY.md** — coverage targets (90% per package), testify/mock patterns, table-driven tests, goroutine lifecycle rules
- **docs/CONVENTIONS.md** — package naming, godoc requirements, interface design, error handling, Python script conventions
- **docs/EXECUTION_PLAN_TEMPLATE.md** — structured template for complex agent tasks
- **scripts/agent-lint.sh** — 5 architectural invariant checks with agent-readable error messages (WHAT / FIX / REF format)
- **.github/workflows/agent-lint.yml** — CI gate with race detector (orchestrator + skillbank + agents)

### Lints enforced
1. **reverse-dependency** — internal/ must not import from cmd/; pkg/ must not import from internal/
2. **missing-godoc** — all exported symbols require godoc comments
3. **global-state** — warning on exported package-level vars (sentinel errors exempted)
4. **build-failure** — go build ./... must pass
5. **agents-too-long** — AGENTS.md must stay under 150 lines

### Why
Encoding invariants mechanically means agents get clear failure messages with fix instructions instead of vague style guidelines. This prevents architectural drift without human review on every PR.

### Reference
https://openai.com/index/harness-engineering/