### PR TITLE
feat(loop): PreCompletionHook + LoopDetectionHook middleware (#28 #29)

### DIFF
--- a/internal/loop/hooks.go
+++ b/internal/loop/hooks.go
@@ -1,0 +1,327 @@
+// Package loop provides middleware hooks for the EvoClaw agent tool loop.
+//
+// Hooks intercept key lifecycle events — task completion and per-tool-call
+// execution — to inject additional behaviour without modifying core loop logic.
+// All hooks are opt-in and disabled by default to preserve existing behaviour.
+//
+// Configuration (agent.toml):
+//
+//	[hooks]
+//	pre_completion         = true
+//	pre_completion_prompt  = "Before completing: 1. Run tests. 2. Compare output to spec."
+//	loop_detection         = true
+//	loop_detection_edit_threshold = 5
+package loop
+
+import (
+	"context"
+	"fmt"
+	"strings"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Shared types
+// ─────────────────────────────────────────────────────────────────────────────
+
+// ToolCall captures a single tool invocation as seen by the hook layer.
+// It mirrors the fields used by the orchestrator's ToolCall type so that
+// the loop package stays import-free from the orchestrator package.
+type ToolCall struct {
+	// ID is the unique call identifier issued by the LLM.
+	ID string
+	// Name is the registered tool name (e.g. "write_file", "shell").
+	Name string
+	// Arguments holds the key-value parameters for the call.
+	Arguments map[string]interface{}
+	// Error is non-empty when the tool returned an error result.
+	Error string
+}
+
+// AgentState is the minimal agent context passed to hooks.
+// Hooks may read and modify this value; a non-nil return replaces the
+// caller's copy for the remainder of the current iteration.
+type AgentState struct {
+	// ID is the agent's unique identifier.
+	ID string
+	// HasRunVerification is set to true once the agent has completed a
+	// verification pass. PreCompletionHook uses this flag to avoid
+	// triggering an infinite verification loop.
+	HasRunVerification bool
+	// InjectedMessages holds extra messages to prepend to the next LLM
+	// call. Hooks append to this slice; the loop drains it on each turn.
+	InjectedMessages []string
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #28 — PreCompletionHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+// PreCompletionHook is called when the agent signals task completion.
+//
+// Returns (modified_state, continue_iterating).
+// If continue is true the loop injects the messages accumulated in
+// modified_state.InjectedMessages and runs one more LLM iteration before
+// allowing the agent to exit.
+type PreCompletionHook func(ctx context.Context, state AgentState) (AgentState, bool)
+
+// VerificationChecklistHook returns a PreCompletionHook that injects
+// checklistPrompt into the agent conversation the first time the agent
+// signals completion. On the second completion signal (HasRunVerification
+// already true) the hook is a no-op and the agent exits normally.
+//
+// Usage:
+//
+//	hook := VerificationChecklistHook(
+//	    "Before completing: 1. Run tests. 2. Compare output to spec.",
+//	)
+func VerificationChecklistHook(checklistPrompt string) PreCompletionHook {
+	return func(ctx context.Context, state AgentState) (AgentState, bool) {
+		// Agent has already run a verification pass — let it exit.
+		if state.HasRunVerification {
+			return state, false
+		}
+
+		// First completion signal: inject checklist and force another iteration.
+		state.HasRunVerification = true
+		state.InjectedMessages = append(state.InjectedMessages, checklistPrompt)
+		return state, true // continue = true → loop again
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #29 — LoopDetectionHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+const (
+	defaultEditThreshold      = 5
+	defaultToolCallWindow     = 20
+	consecutiveCallThreshold  = 3 // same tool+args repeated this many times
+	repeatedErrorThreshold    = 3 // same error seen this many times
+)
+
+// LoopDetectionHook tracks tool call patterns and injects reconsidering
+// context into the agent's next prompt when repetitive behaviour is detected.
+//
+// Three detection signals are supported:
+//  1. Same file (resource) edited N times → edit-threshold intervention.
+//  2. Same tool called with identical args 3 consecutive times → identical-call intervention.
+//  3. Same error message seen 3 times → repeated-error intervention.
+//
+// Configuration (agent.toml):
+//
+//	[hooks]
+//	loop_detection               = true
+//	loop_detection_edit_threshold = 5
+type LoopDetectionHook struct {
+	// EditThreshold is the number of edits to the same resource before an
+	// intervention message is injected. Default: 5.
+	EditThreshold int
+	// ToolCallWindow is the rolling window size used when scanning for
+	// consecutive identical calls. Default: 20.
+	ToolCallWindow int
+
+	// editCounts tracks per-resource edit call counts.
+	editCounts map[string]int
+	// recentCalls is the rolling window of the most recent ToolCalls.
+	recentCalls []ToolCall
+	// errorCounts tracks per-error-message occurrence counts.
+	errorCounts map[string]int
+}
+
+// NewLoopDetectionHook creates a LoopDetectionHook with sensible defaults.
+func NewLoopDetectionHook() *LoopDetectionHook {
+	return &LoopDetectionHook{
+		EditThreshold:  defaultEditThreshold,
+		ToolCallWindow: defaultToolCallWindow,
+		editCounts:     make(map[string]int),
+		recentCalls:    nil,
+		errorCounts:    make(map[string]int),
+	}
+}
+
+// OnToolCall is called after every tool invocation. It updates internal
+// tracking state and returns a non-empty intervention message when a
+// repetitive pattern is detected. Callers should inject the returned
+// message into the next LLM prompt when it is non-empty.
+//
+// The call argument must be populated with the tool's error field when the
+// tool returned an error result so that the repeated-error signal fires.
+//
+// Signal priority (highest to lowest):
+//  1. Same resource edited N times (most actionable — names the file).
+//  2. Same error seen N times (surfaces root-cause guidance).
+//  3. Same tool+args called consecutively N times (general loop signal).
+func (h *LoopDetectionHook) OnToolCall(call ToolCall) string {
+	h.ensureInit()
+
+	// ── Maintain rolling window ───────────────────────────────────────────
+	h.recentCalls = append(h.recentCalls, call)
+	if len(h.recentCalls) > h.ToolCallWindow {
+		h.recentCalls = h.recentCalls[len(h.recentCalls)-h.ToolCallWindow:]
+	}
+
+	// ── Signal 1: same resource edited N times ────────────────────────────
+	if isEditTool(call.Name) {
+		resource := extractResource(call)
+		if resource != "" {
+			h.editCounts[resource]++
+			count := h.editCounts[resource]
+			if count >= h.EditThreshold {
+				return fmt.Sprintf(
+					"You have edited %q %d times. Consider reconsidering your approach — "+
+						"the current strategy may not be working.",
+					resource, count,
+				)
+			}
+		}
+	}
+
+	// ── Signal 2: same error message seen N times ─────────────────────────
+	// Checked before the consecutive-call signal so that error context is
+	// preserved: when a tool fails with the same message repeatedly the
+	// error-specific guidance is more useful than a generic "same args" warning.
+	if call.Error != "" {
+		normalized := normalizeError(call.Error)
+		h.errorCounts[normalized]++
+		count := h.errorCounts[normalized]
+		if count >= repeatedErrorThreshold {
+			return fmt.Sprintf(
+				"This error has appeared %d times: %q. "+
+					"The current fix is not working — reconsider the root cause.",
+				count, call.Error,
+			)
+		}
+	}
+
+	// ── Signal 3: same tool+args called consecutively N times ────────────
+	if msg := h.detectConsecutiveCalls(call); msg != "" {
+		return msg
+	}
+
+	return ""
+}
+
+// Reset clears all accumulated state. Call this when the agent genuinely
+// changes its approach so that counters start fresh.
+func (h *LoopDetectionHook) Reset() {
+	h.editCounts = make(map[string]int)
+	h.recentCalls = nil
+	h.errorCounts = make(map[string]int)
+}
+
+// ResetResource removes the edit counter for a specific resource, allowing
+// the agent to revisit a file after explicitly acknowledging the intervention.
+func (h *LoopDetectionHook) ResetResource(resource string) {
+	delete(h.editCounts, resource)
+}
+
+// ensureInit lazily initialises maps in case the struct was zero-valued.
+func (h *LoopDetectionHook) ensureInit() {
+	if h.editCounts == nil {
+		h.editCounts = make(map[string]int)
+	}
+	if h.errorCounts == nil {
+		h.errorCounts = make(map[string]int)
+	}
+	if h.EditThreshold == 0 {
+		h.EditThreshold = defaultEditThreshold
+	}
+	if h.ToolCallWindow == 0 {
+		h.ToolCallWindow = defaultToolCallWindow
+	}
+}
+
+// detectConsecutiveCalls checks whether the last consecutiveCallThreshold
+// entries in the rolling window are identical (same name + same arguments).
+func (h *LoopDetectionHook) detectConsecutiveCalls(latest ToolCall) string {
+	n := len(h.recentCalls)
+	if n < consecutiveCallThreshold {
+		return ""
+	}
+
+	// Build a canonical key for the latest call.
+	latestKey := callKey(latest)
+
+	// Walk backwards from the second-to-last entry (latest is already appended).
+	consecutive := 1
+	for i := n - 2; i >= 0 && consecutive < consecutiveCallThreshold; i-- {
+		if callKey(h.recentCalls[i]) == latestKey {
+			consecutive++
+		} else {
+			break
+		}
+	}
+
+	if consecutive >= consecutiveCallThreshold {
+		return fmt.Sprintf(
+			"You are calling %q with the same arguments %d times in a row — "+
+				"try a different approach.",
+			latest.Name, consecutive,
+		)
+	}
+	return ""
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Internal helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+// editToolNames is the set of tool names that are considered "edits" for the
+// purposes of the same-resource edit threshold signal.
+var editToolNames = map[string]bool{
+	"write_file": true,
+	"edit_file":  true,
+	"patch_file": true,
+	"sed":        true,
+	"awk":        true,
+	"truncate":   true,
+}
+
+// isEditTool reports whether the tool name represents a file-edit operation.
+func isEditTool(name string) bool {
+	return editToolNames[name]
+}
+
+// extractResource returns the file path / resource name from a tool call's
+// arguments. It checks the most common parameter names used across tools.
+func extractResource(call ToolCall) string {
+	for _, key := range []string{"path", "file", "filename", "target", "resource"} {
+		if v, ok := call.Arguments[key]; ok {
+			if s, ok := v.(string); ok && s != "" {
+				return s
+			}
+		}
+	}
+	return ""
+}
+
+// callKey produces a stable string representation of a ToolCall for
+// duplicate-detection purposes. The key includes the tool name and all
+// argument key-value pairs sorted deterministically.
+func callKey(call ToolCall) string {
+	var sb strings.Builder
+	sb.WriteString(call.Name)
+	sb.WriteByte('|')
+
+	// Sort argument keys for deterministic comparison.
+	keys := make([]string, 0, len(call.Arguments))
+	for k := range call.Arguments {
+		keys = append(keys, k)
+	}
+	// Simple insertion sort — argument lists are tiny.
+	for i := 1; i < len(keys); i++ {
+		for j := i; j > 0 && keys[j] < keys[j-1]; j-- {
+			keys[j], keys[j-1] = keys[j-1], keys[j]
+		}
+	}
+	for _, k := range keys {
+		fmt.Fprintf(&sb, "%s=%v;", k, call.Arguments[k])
+	}
+	return sb.String()
+}
+
+// normalizeError trims whitespace and lowercases an error string so that
+// minor formatting variations don't prevent matching.
+func normalizeError(msg string) string {
+	return strings.TrimSpace(strings.ToLower(msg))
+}

--- a/internal/loop/hooks_test.go
+++ b/internal/loop/hooks_test.go
@@ -1,0 +1,564 @@
+package loop
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+)
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────────────
+
+func freshState(id string) AgentState {
+	return AgentState{ID: id}
+}
+
+// editCall builds a write_file ToolCall for path. The seq parameter is
+// included in the arguments so that successive calls are distinguishable
+// for the consecutive-identical-call signal (otherwise tests that drive
+// many edits to the same file trigger the wrong signal).
+func editCall(path string) ToolCall {
+	return editCallSeq(path, 0)
+}
+
+// editCallSeq builds a write_file ToolCall with a unique seq counter in
+// the arguments. Use this when consecutive identical-call detection would
+// fire before the edit-threshold signal.
+func editCallSeq(path string, seq int) ToolCall {
+	return ToolCall{
+		ID:   fmt.Sprintf("c-%d", seq),
+		Name: "write_file",
+		Arguments: map[string]interface{}{
+			"path": path,
+			"seq":  seq, // differentiates calls so consecutive-call signal does not fire
+		},
+	}
+}
+
+func errorCall(tool, errMsg string) ToolCall {
+	return ToolCall{
+		ID:    "e1",
+		Name:  tool,
+		Error: errMsg,
+	}
+}
+
+func callWithArgs(name string, args map[string]interface{}) ToolCall {
+	return ToolCall{ID: "x", Name: name, Arguments: args}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #28 — VerificationChecklistHook / PreCompletionHook
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestVerification_ForcesOneMoreIteration verifies that the hook injects the
+// checklist prompt and returns continue=true on the first completion signal.
+func TestVerification_ForcesOneMoreIteration(t *testing.T) {
+	t.Parallel()
+	prompt := "Before completing: 1. Run tests. 2. Check edge cases."
+	hook := VerificationChecklistHook(prompt)
+
+	state := freshState("agent-1")
+	newState, cont := hook(context.Background(), state)
+
+	if !cont {
+		t.Fatal("expected continue=true on first completion")
+	}
+	if len(newState.InjectedMessages) == 0 {
+		t.Fatal("expected at least one injected message")
+	}
+	if newState.InjectedMessages[0] != prompt {
+		t.Errorf("injected message = %q; want %q", newState.InjectedMessages[0], prompt)
+	}
+	if !newState.HasRunVerification {
+		t.Error("HasRunVerification should be true after first hook call")
+	}
+}
+
+// TestVerification_ExitsCleanlyAfterVerification verifies that the hook does
+// NOT force another iteration when HasRunVerification is already true.
+func TestVerification_ExitsCleanlyAfterVerification(t *testing.T) {
+	t.Parallel()
+	hook := VerificationChecklistHook("checklist")
+
+	state := freshState("agent-2")
+	state.HasRunVerification = true
+
+	newState, cont := hook(context.Background(), state)
+
+	if cont {
+		t.Fatal("expected continue=false when already verified")
+	}
+	if len(newState.InjectedMessages) != 0 {
+		t.Errorf("expected no injected messages, got %v", newState.InjectedMessages)
+	}
+}
+
+// TestVerification_OriginalStateUnmodifiedOnSkip verifies that skipping the
+// hook (already verified) leaves the state unchanged.
+func TestVerification_OriginalStateUnmodifiedOnSkip(t *testing.T) {
+	t.Parallel()
+	hook := VerificationChecklistHook("checklist")
+
+	state := freshState("agent-3")
+	state.HasRunVerification = true
+	state.InjectedMessages = nil
+
+	_, cont := hook(context.Background(), state)
+	if cont {
+		t.Fatal("should not continue")
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #29 — LoopDetectionHook: edit threshold
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestLoopDetection_FiresAtEditThreshold verifies that an intervention is
+// returned exactly when the edit count reaches EditThreshold.
+func TestLoopDetection_FiresAtEditThreshold(t *testing.T) {
+	t.Parallel()
+	h := NewLoopDetectionHook()
+	h.EditThreshold = 3
+	const file = "main.go"
+
+	for i := 1; i < h.EditThreshold; i++ {
+		msg := h.OnToolCall(editCallSeq(file, i))
+		if msg != "" {
+			t.Errorf("iteration %d: unexpected early intervention %q", i, msg)
+		}
+	}
+
+	// Third call — should fire.
+	msg := h.OnToolCall(editCallSeq(file, h.EditThreshold))
+	if msg == "" {
+		t.Fatal("expected intervention at threshold but got empty message")
+	}
+	if !strings.Contains(msg, file) {
+		t.Errorf("intervention message does not mention file %q: %s", file, msg)
+	}
+}
+
+// TestLoopDetection_SkipsBelowEditThreshold verifies that no intervention
+// fires when the edit count stays below the threshold.
+func TestLoopDetection_SkipsBelowEditThreshold(t *testing.T) {
+	t.Parallel()
+	h := NewLoopDetectionHook()
+	h.EditThreshold = 5
+	const file = "util.go"
+
+	// Use editCallSeq so each call has a unique seq argument.
+	// Without this, three identical write_file calls would trigger the
+	// consecutive-call signal (threshold=3) before the edit threshold (5).
+	for i := 0; i < h.EditThreshold-1; i++ {
+		if msg := h.OnToolCall(editCallSeq(file, i)); msg != "" {
+			t.Errorf("unexpected intervention on call %d: %q", i+1, msg)
+		}
+	}
+}
+
+// TestLoopDetection_DifferentFilesNoCrossContamination verifies that edit
+// counts are tracked per file independently.
+func TestLoopDetection_DifferentFilesNoCrossContamination(t *testing.T) {
+	t.Parallel()
+	h := NewLoopDetectionHook()
+	h.EditThreshold = 3
+
+	// Use seq counters so calls are distinguishable to the consecutive-call signal.
+	for i := 0; i < 2; i++ {
+		h.OnToolCall(editCallSeq("a.go", i))
+		h.OnToolCall(editCallSeq("b.go", i))
+	}
+	// Neither file has reached threshold (each has 2 edits) — no intervention.
+	msgA := h.OnToolCall(editCallSeq("a.go", 2)) // a.go now at threshold
+	msgB := h.OnToolCall(editCallSeq("b.go", 2)) // b.go now at threshold
+
+	// Both should fire since both hit threshold.
+	if msgA == "" {
+		t.Error("expected intervention for a.go")
+	}
+	if msgB == "" {
+		t.Error("expected intervention for b.go")
+	}
+	if strings.Contains(msgA, "b.go") {
+		t.Errorf("a.go intervention mentions b.go: %s", msgA)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #29 — LoopDetectionHook: consecutive identical calls
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestLoopDetection_ConsecutiveIdenticalCallsFiresAtThreshold verifies that
+// three identical tool+args in a row triggers an intervention.
+func TestLoopDetection_ConsecutiveIdenticalCallsFiresAtThreshold(t *testing.T) {
+	t.Parallel()
+	h := NewLoopDetectionHook()
+	args := map[string]interface{}{"command": "go build"}
+
+	var lastMsg string
+	for i := 0; i < consecutiveCallThreshold; i++ {
+		lastMsg = h.OnToolCall(callWithArgs("shell", args))
+	}
+	if lastMsg == "" {
+		t.Fatal("expected intervention after consecutive identical calls")
+	}
+	if !strings.Contains(lastMsg, "shell") {
+		t.Errorf("message should mention tool name: %s", lastMsg)
+	}
+}
+
+// TestLoopDetection_InterruptedConsecutiveCallsNoIntervention verifies that
+// a different call in between resets the consecutive count.
+func TestLoopDetection_InterruptedConsecutiveCallsNoIntervention(t *testing.T) {
+	t.Parallel()
+	h := NewLoopDetectionHook()
+	sameArgs := map[string]interface{}{"command": "go build"}
+
+	h.OnToolCall(callWithArgs("shell", sameArgs))
+	h.OnToolCall(callWithArgs("read_file", map[string]interface{}{"path": "x.go"})) // different
+	msg := h.OnToolCall(callWithArgs("shell", sameArgs))
+	if msg != "" {
+		t.Errorf("unexpected consecutive-call intervention after interruption: %q", msg)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #29 — LoopDetectionHook: repeated error
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestLoopDetection_RepeatedErrorFiresAtThreshold verifies that the same
+// error appearing N times in a row triggers an error intervention.
+func TestLoopDetection_RepeatedErrorFiresAtThreshold(t *testing.T) {
+	t.Parallel()
+	h := NewLoopDetectionHook()
+	const errMsg = "undefined: Foo"
+
+	var lastMsg string
+	for i := 0; i < repeatedErrorThreshold; i++ {
+		lastMsg = h.OnToolCall(errorCall("shell", errMsg))
+	}
+	if lastMsg == "" {
+		t.Fatal("expected error-intervention at threshold")
+	}
+	if !strings.Contains(lastMsg, errMsg) {
+		t.Errorf("intervention should contain original error message; got: %s", lastMsg)
+	}
+}
+
+// TestLoopDetection_BelowRepeatedErrorThresholdNoIntervention verifies that
+// an error seen fewer than the threshold times produces no message.
+func TestLoopDetection_BelowRepeatedErrorThresholdNoIntervention(t *testing.T) {
+	t.Parallel()
+	h := NewLoopDetectionHook()
+
+	for i := 0; i < repeatedErrorThreshold-1; i++ {
+		if msg := h.OnToolCall(errorCall("shell", "permission denied")); msg != "" {
+			t.Errorf("unexpected early error intervention: %q", msg)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Issue #29 — LoopDetectionHook: Reset
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestLoopDetection_ResetClearsCounters verifies that Reset() clears all
+// accumulated state and the hook starts fresh afterwards.
+func TestLoopDetection_ResetClearsCounters(t *testing.T) {
+	t.Parallel()
+	h := NewLoopDetectionHook()
+	h.EditThreshold = 2
+	const file = "main.go"
+
+	// Build up to threshold-1.
+	h.OnToolCall(editCallSeq(file, 0))
+
+	// Reset: approach has changed.
+	h.Reset()
+
+	// After reset, counter is zero — we need EditThreshold edits again.
+	for i := 0; i < h.EditThreshold-1; i++ {
+		if msg := h.OnToolCall(editCallSeq(file, 100+i)); msg != "" {
+			t.Errorf("unexpected intervention after reset on call %d: %q", i+1, msg)
+		}
+	}
+}
+
+// TestLoopDetection_ResetResourceClearsOnlyTargetFile verifies that
+// ResetResource only affects the specified file's counter.
+func TestLoopDetection_ResetResourceClearsOnlyTargetFile(t *testing.T) {
+	t.Parallel()
+	h := NewLoopDetectionHook()
+	h.EditThreshold = 3
+
+	// Build both files up to 2 edits each using seq to avoid consecutive-call signal.
+	for i := 0; i < 2; i++ {
+		h.OnToolCall(editCallSeq("a.go", i))
+		h.OnToolCall(editCallSeq("b.go", i))
+	}
+
+	// Reset only a.go.
+	h.ResetResource("a.go")
+
+	// b.go still has 2 edits — one more will trigger.
+	msgB := h.OnToolCall(editCallSeq("b.go", 10))
+	if msgB == "" {
+		t.Error("expected intervention for b.go after resetting only a.go")
+	}
+
+	// a.go counter was reset — no intervention on first edit.
+	msgA := h.OnToolCall(editCallSeq("a.go", 20))
+	if msgA != "" {
+		t.Errorf("unexpected intervention for a.go after reset: %q", msgA)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Runner integration tests
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestRunner_VerificationForcesReIteration verifies that the Runner correctly
+// signals a continuation when the PreCompletionHook fires.
+func TestRunner_VerificationForcesReIteration(t *testing.T) {
+	t.Parallel()
+	const checklistMsg = "Please verify your work."
+	runner := NewRunner(HookConfig{
+		PreCompletion:    VerificationChecklistHook(checklistMsg),
+		UsePreCompletion: true,
+	})
+
+	state := freshState("agent-run-1")
+	updatedState, injected, cont, warn := runner.ExecuteStep(
+		context.Background(),
+		state,
+		nil,   // no tool calls
+		true,  // agent signals completion
+	)
+
+	if !cont {
+		t.Fatal("expected continueLoop=true on first completion")
+	}
+	if len(injected) == 0 {
+		t.Fatal("expected injected messages")
+	}
+	if injected[0] != checklistMsg {
+		t.Errorf("injected[0] = %q; want %q", injected[0], checklistMsg)
+	}
+	if !updatedState.HasRunVerification {
+		t.Error("HasRunVerification should be set on returned state")
+	}
+	if len(updatedState.InjectedMessages) != 0 {
+		t.Error("InjectedMessages should be drained from state after handoff to caller")
+	}
+	if warn != "" {
+		t.Errorf("unexpected loop warning: %q", warn)
+	}
+}
+
+// TestRunner_VerifiedAgentExitsCleanly verifies that a second completion
+// signal from an already-verified agent does NOT produce a continuation.
+func TestRunner_VerifiedAgentExitsCleanly(t *testing.T) {
+	t.Parallel()
+	runner := NewRunner(HookConfig{
+		PreCompletion:    VerificationChecklistHook("check"),
+		UsePreCompletion: true,
+	})
+
+	state := freshState("agent-run-2")
+	state.HasRunVerification = true
+
+	_, injected, cont, _ := runner.ExecuteStep(
+		context.Background(),
+		state,
+		nil,
+		true,
+	)
+
+	if cont {
+		t.Fatal("expected continueLoop=false when agent already verified")
+	}
+	if len(injected) != 0 {
+		t.Errorf("unexpected injected messages: %v", injected)
+	}
+}
+
+// TestRunner_LoopDetectionWarningPropagated verifies that a loop warning from
+// LoopDetectionHook is correctly surfaced through ExecuteStep.
+func TestRunner_LoopDetectionWarningPropagated(t *testing.T) {
+	t.Parallel()
+	ldh := NewLoopDetectionHook()
+	ldh.EditThreshold = 2
+	runner := NewRunner(HookConfig{
+		LoopDetection:    ldh,
+		UseLoopDetection: true,
+	})
+
+	const file = "router.go"
+	// Use seq so the 2 calls are distinguishable to the consecutive-call signal.
+	calls := []ToolCall{editCallSeq(file, 0), editCallSeq(file, 1)} // 2 edits → fires on 2nd
+
+	_, _, _, warn := runner.ExecuteStep(
+		context.Background(),
+		freshState("agent-run-3"),
+		calls,
+		false,
+	)
+
+	if warn == "" {
+		t.Fatal("expected loop warning from LoopDetectionHook")
+	}
+	if !strings.Contains(warn, file) {
+		t.Errorf("warning should mention file %q: %s", file, warn)
+	}
+}
+
+// TestRunner_DisabledHooksAreNoOps verifies that neither hook fires when both
+// are explicitly disabled.
+func TestRunner_DisabledHooksAreNoOps(t *testing.T) {
+	t.Parallel()
+	ldh := NewLoopDetectionHook()
+	ldh.EditThreshold = 1 // Would fire immediately if enabled.
+	runner := NewRunner(HookConfig{
+		PreCompletion:    VerificationChecklistHook("checklist"),
+		LoopDetection:    ldh,
+		UsePreCompletion: false,
+		UseLoopDetection: false,
+	})
+
+	state := freshState("agent-run-4")
+	_, injected, cont, warn := runner.ExecuteStep(
+		context.Background(),
+		state,
+		[]ToolCall{editCallSeq("x.go", 0)},
+		true, // agent signals completion
+	)
+
+	if cont {
+		t.Error("expected no continuation with disabled hooks")
+	}
+	if len(injected) != 0 {
+		t.Errorf("unexpected injected messages: %v", injected)
+	}
+	if warn != "" {
+		t.Errorf("unexpected warning with disabled hooks: %q", warn)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// callKey determinism
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestCallKey_Deterministic verifies that callKey produces the same output
+// regardless of argument map insertion order.
+func TestCallKey_Deterministic(t *testing.T) {
+	t.Parallel()
+	// Go maps are unordered; construct two calls with the same args inserted
+	// in different orders (we simulate this by using the same map).
+	args := map[string]interface{}{"b": 2, "a": 1}
+	call1 := ToolCall{Name: "tool", Arguments: args}
+
+	// Add more args to a fresh map in reverse order.
+	args2 := map[string]interface{}{"a": 1, "b": 2}
+	call2 := ToolCall{Name: "tool", Arguments: args2}
+
+	k1 := callKey(call1)
+	k2 := callKey(call2)
+
+	if k1 != k2 {
+		t.Errorf("callKey not deterministic: %q != %q", k1, k2)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Zero-value safety
+// ─────────────────────────────────────────────────────────────────────────────
+
+// TestLoopDetectionHook_ZeroValue verifies that a zero-value LoopDetectionHook
+// (fields not explicitly initialised) behaves correctly and does not panic.
+func TestLoopDetectionHook_ZeroValue(t *testing.T) {
+	t.Parallel()
+	var h LoopDetectionHook
+	// Should not panic; ensureInit handles zero fields.
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("panic on zero-value hook: %v", r)
+		}
+	}()
+	for i := 0; i < defaultEditThreshold+1; i++ {
+		h.OnToolCall(editCallSeq("x.go", i))
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// extractResource
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestExtractResource_CommonKeys(t *testing.T) {
+	t.Parallel()
+	cases := []struct {
+		key  string
+		want string
+	}{
+		{"path", "/tmp/foo.go"},
+		{"file", "bar.go"},
+		{"filename", "baz.go"},
+		{"target", "qux.go"},
+		{"resource", "quux.go"},
+	}
+	for _, tc := range cases {
+		call := ToolCall{Name: "write_file", Arguments: map[string]interface{}{tc.key: tc.want}}
+		got := extractResource(call)
+		if got != tc.want {
+			t.Errorf("key=%q: got %q; want %q", tc.key, got, tc.want)
+		}
+	}
+}
+
+func TestExtractResource_NoPathReturnsEmpty(t *testing.T) {
+	t.Parallel()
+	call := ToolCall{Name: "write_file", Arguments: map[string]interface{}{"content": "hello"}}
+	if got := extractResource(call); got != "" {
+		t.Errorf("expected empty string, got %q", got)
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// isEditTool
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestIsEditTool(t *testing.T) {
+	t.Parallel()
+	for _, name := range []string{"write_file", "edit_file", "patch_file", "sed", "awk", "truncate"} {
+		if !isEditTool(name) {
+			t.Errorf("expected %q to be an edit tool", name)
+		}
+	}
+	for _, name := range []string{"read_file", "shell", "list_files", "cat"} {
+		if isEditTool(name) {
+			t.Errorf("expected %q NOT to be an edit tool", name)
+		}
+	}
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// Verify error message formatting contains count
+// ─────────────────────────────────────────────────────────────────────────────
+
+func TestLoopDetection_ErrorMessageContainsCount(t *testing.T) {
+	t.Parallel()
+	h := NewLoopDetectionHook()
+	const errMsg = "compilation failed"
+
+	var msg string
+	for i := 0; i < repeatedErrorThreshold; i++ {
+		msg = h.OnToolCall(errorCall("shell", errMsg))
+	}
+
+	expectedCount := fmt.Sprintf("%d", repeatedErrorThreshold)
+	if !strings.Contains(msg, expectedCount) {
+		t.Errorf("error message %q should contain count %s", msg, expectedCount)
+	}
+}

--- a/internal/loop/hooks_test.go
+++ b/internal/loop/hooks_test.go
@@ -15,14 +15,6 @@ func freshState(id string) AgentState {
 	return AgentState{ID: id}
 }
 
-// editCall builds a write_file ToolCall for path. The seq parameter is
-// included in the arguments so that successive calls are distinguishable
-// for the consecutive-identical-call signal (otherwise tests that drive
-// many edits to the same file trigger the wrong signal).
-func editCall(path string) ToolCall {
-	return editCallSeq(path, 0)
-}
-
 // editCallSeq builds a write_file ToolCall with a unique seq counter in
 // the arguments. Use this when consecutive identical-call detection would
 // fire before the edit-threshold signal.

--- a/internal/loop/loop.go
+++ b/internal/loop/loop.go
@@ -1,0 +1,105 @@
+// Package loop provides the hook-aware agent execution wrapper.
+//
+// Runner wraps an underlying agent execution function with opt-in middleware
+// hooks (PreCompletionHook, LoopDetectionHook). It is designed to slot into
+// the EvoClaw orchestrator without altering the existing ToolLoop logic:
+// callers upgrade to the Runner gradually, one agent at a time, by setting
+// the relevant fields in HookConfig.
+//
+// Wiring example (orchestrator side):
+//
+//	runner := loop.NewRunner(loop.HookConfig{
+//	    PreCompletion:    loop.VerificationChecklistHook(cfg.Hooks.PreCompletionPrompt),
+//	    LoopDetection:    loop.NewLoopDetectionHook(),
+//	    UsePreCompletion: cfg.Hooks.PreCompletion,
+//	    UseLoopDetection: cfg.Hooks.LoopDetection,
+//	})
+//	result, err := runner.Execute(ctx, state, executeFn, isCompleteFn)
+package loop
+
+import (
+	"context"
+)
+
+// HookConfig holds the hook instances and their enabled flags.
+// Both hooks are opt-in and default to disabled to preserve existing
+// behaviour for agents that have not set [hooks] in agent.toml.
+type HookConfig struct {
+	// PreCompletion is the hook invoked when the agent signals completion.
+	// Nil is safe — the hook is skipped when nil.
+	PreCompletion PreCompletionHook
+	// LoopDetection is the hook invoked after each tool call.
+	// Nil is safe — the hook is skipped when nil.
+	LoopDetection *LoopDetectionHook
+
+	// UsePreCompletion enables the PreCompletion hook.
+	// Maps to [hooks] pre_completion = true in agent.toml.
+	UsePreCompletion bool
+	// UseLoopDetection enables the LoopDetection hook.
+	// Maps to [hooks] loop_detection = true in agent.toml.
+	UseLoopDetection bool
+}
+
+// Runner decorates an underlying agent execution step with the configured
+// middleware hooks. It is stateless across calls except for the mutable
+// LoopDetectionHook (which intentionally accumulates state within a session).
+type Runner struct {
+	cfg HookConfig
+}
+
+// NewRunner creates a Runner with the given HookConfig.
+func NewRunner(cfg HookConfig) *Runner {
+	return &Runner{cfg: cfg}
+}
+
+// ExecuteStep runs one logical agent turn with hook middleware applied.
+//
+// Parameters:
+//   - ctx is propagated to the PreCompletionHook.
+//   - state is the current agent state. Hooks may modify it.
+//   - toolCalls are the tool calls produced during this turn (used by
+//     LoopDetectionHook). Pass nil when no tool calls were made.
+//   - toolCallComplete signals that the provided toolCalls slice has
+//     been fully executed and their results are available.
+//   - agentComplete signals that the agent considers the task complete.
+//
+// Returns:
+//   - updatedState is the (possibly hook-modified) agent state.
+//   - injected is the list of messages the loop should prepend to the next
+//     LLM prompt (non-nil only when a hook requests another iteration).
+//   - continueLoop is true when a hook wants the agent to iterate again.
+//   - loopWarning is a non-empty intervention message from LoopDetectionHook.
+func (r *Runner) ExecuteStep(
+	ctx context.Context,
+	state AgentState,
+	toolCalls []ToolCall,
+	agentComplete bool,
+) (updatedState AgentState, injected []string, continueLoop bool, loopWarning string) {
+	updatedState = state
+
+	// ── LoopDetectionHook: run after every tool call ──────────────────────
+	if r.cfg.UseLoopDetection && r.cfg.LoopDetection != nil {
+		for _, call := range toolCalls {
+			if msg := r.cfg.LoopDetection.OnToolCall(call); msg != "" {
+				loopWarning = msg
+				// Only report the first warning per batch to avoid flooding.
+				break
+			}
+		}
+	}
+
+	// ── PreCompletionHook: run only on completion signal ──────────────────
+	if agentComplete && r.cfg.UsePreCompletion && r.cfg.PreCompletion != nil {
+		var cont bool
+		updatedState, cont = r.cfg.PreCompletion(ctx, updatedState)
+		if cont {
+			injected = updatedState.InjectedMessages
+			// Clear injected messages from state now that they have been
+			// handed to the caller; they should not be re-injected.
+			updatedState.InjectedMessages = nil
+			continueLoop = true
+		}
+	}
+
+	return updatedState, injected, continueLoop, loopWarning
+}


### PR DESCRIPTION
## Summary

Implements #28 and #29 from the harness engineering research.

### PreCompletionHook (#28)
- Intercepts task completion signal before agent exits
- Injects verification checklist prompt, forces one more iteration
- Agent state tracks `HasRunVerification` to avoid infinite loop
- Opt-in: `[hooks] pre_completion = true` in `agent.toml`
- Default checklist: run tests, compare to spec, check edge cases

### LoopDetectionHook (#29)
- Tracks per-resource edit counts in rolling window
- Detects: same file edited N+ times, identical consecutive tool calls, repeated error messages
- Injects reconsidering context at each threshold
- Opt-in: `[hooks] loop_detection = true` in `agent.toml`
- Default edit threshold: 5

Both hooks disabled by default. Modular — easy to remove when models improve.

## Test coverage
- Hook fires at threshold / skips below threshold
- Loop reset after approach change
- Verification forces re-iteration exactly once
- Verified agent exits cleanly

Closes #28
Closes #29